### PR TITLE
Add option for allowing the grouping of paths.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/carousell/fasthttp-prometheus-middleware
 go 1.13
 
 require (
-	github.com/fasthttp/router v0.5.2
+	github.com/fasthttp/router v1.3.2
 	github.com/prometheus/client_golang v1.2.1
 	github.com/valyala/fasthttp v1.6.0
 )


### PR DESCRIPTION
For routers that have variables in the path, the HistoGram
instance can become huge. This can be both a memory problem
and a problem for prometheus scrape times.

This change adds an option to group the path in the prom
metrics such that the matching route name is used instead
of the request uri path.

Note, this commit also alters the histogram fields by creating a 
separate entry for method instead of prepending to the path.