### PR TITLE
fix: panic with invalid labels

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -1,6 +1,7 @@
 package fasthttpprom
 
 import (
+	"log"
 	"strconv"
 	"time"
 
@@ -114,7 +115,12 @@ func (p *Prometheus) HandlerFunc() fasthttp.RequestHandler {
 		status := strconv.Itoa(ctx.Response.StatusCode())
 		elapsed := float64(time.Since(start)) / float64(time.Second)
 		ep := string(ctx.Method()) + "_" + uri
-		p.reqDur.WithLabelValues(status, ep).Observe(elapsed)
+		ob, err := p.reqDur.GetMetricWithLabelValues(status, ep)
+		if err != nil {
+			log.Printf("Fail to GetMetricWithLabelValues: %s\n", err)
+			return
+		}
+		ob.Observe(elapsed)
 	}
 }
 


### PR DESCRIPTION
## README

**Reason:**
- Panic happens when we use this func `WithLabelValues` without knowing it will panic whenever an error return

**Solution:**
- Instead of calling it, we use its super func to do the work `GetMetricWithLabelValues`
- In FACT: `WithLabelValues` call `GetMetricWithLabelValues` under the hood

### DoD
- [ ] Update unit test
- [ ] Manual testing