### PR TITLE
feat: poc-cus-metrics-2025 - POC for custom metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,234 @@ request_duration_seconds_bucket{code="200",path="GET_/health",le="5"} 25063
 request_duration_seconds_bucket{code="200",path="GET_/health",le="+Inf"} 25063
 request_duration_seconds_sum{code="200",path="GET_/health"} 0.14781658099999923
 request_duration_seconds_count{code="200",path="GET_/health"} 25063
+
+## Custom Metrics
+
+You can register your own custom Prometheus metrics (counters, gauges, histograms, summaries) to be exported alongside the default request duration metrics. All registration methods are **thread-safe** and protected by mutex.
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "log"
+    
+    fasthttpprom "github.com/carousell/fasthttp-prometheus-middleware"
+    "github.com/fasthttp/router"
+    "github.com/prometheus/client_golang/prometheus"
+    "github.com/valyala/fasthttp"
+)
+
+func main() {
+    r := router.New()
+    p := fasthttpprom.NewPrometheus("myapp")
+    
+    // Create a custom counter
+    requestCounter := prometheus.NewCounterVec(
+        prometheus.CounterOpts{
+            Name: "myapp_custom_requests_total",
+            Help: "Total number of custom requests",
+        },
+        []string{"endpoint", "method"},
+    )
+    
+    // Register it with the Prometheus middleware
+    if err := p.RegisterMetric(requestCounter); err != nil {
+        log.Fatalf("Failed to register metric: %v", err)
+    }
+    
+    p.Use(r)
+    
+    // Use the metric in your handlers
+    r.GET("/api/users", func(ctx *fasthttp.RequestCtx) {
+        requestCounter.WithLabelValues("/api/users", "GET").Inc()
+        ctx.SetStatusCode(200)
+        ctx.SetBody([]byte(`{"users": []}`))
+    })
+    
+    log.Fatal(fasthttp.ListenAndServe(":8080", p.Handler))
+}
+```
+
+### Available Methods
+
+- **`RegisterMetric(collector prometheus.Collector) error`** - Registers a custom metric. Returns an error if registration fails. Thread-safe.
+- **`MustRegisterMetric(collector prometheus.Collector)`** - Like RegisterMetric but panics on error. Useful during initialization. Thread-safe.
+- **`GetCustomMetrics() []prometheus.Collector`** - Returns a copy of all registered custom metrics. Thread-safe.
+
+### Advanced Pattern: Metrics Module with Handler Functions
+
+For larger applications, organize your metrics in a separate module and pass them to handler functions:
+
+```go
+// metrics/metrics.go
+package metrics
+
+import (
+    "fmt"
+    fasthttpprom "github.com/carousell/fasthttp-prometheus-middleware"
+    "github.com/prometheus/client_golang/prometheus"
+)
+
+type AppMetrics struct {
+    LoginAttempts  *prometheus.CounterVec
+    CacheHits      prometheus.Counter
+    ProcessingTime *prometheus.HistogramVec
+}
+
+func New() *AppMetrics {
+    return &AppMetrics{
+        LoginAttempts: prometheus.NewCounterVec(
+            prometheus.CounterOpts{
+                Name: "app_login_attempts_total",
+                Help: "Total login attempts",
+            },
+            []string{"status", "method"},
+        ),
+        CacheHits: prometheus.NewCounter(
+            prometheus.CounterOpts{
+                Name: "app_cache_hits_total",
+                Help: "Total cache hits",
+            },
+        ),
+        ProcessingTime: prometheus.NewHistogramVec(
+            prometheus.HistogramOpts{
+                Name: "app_processing_seconds",
+                Help: "Processing time",
+            },
+            []string{"operation"},
+        ),
+    }
+}
+
+func (m *AppMetrics) Register(p *fasthttpprom.Prometheus) error {
+    if err := p.RegisterMetric(m.LoginAttempts); err != nil {
+        return fmt.Errorf("failed to register LoginAttempts: %w", err)
+    }
+    if err := p.RegisterMetric(m.CacheHits); err != nil {
+        return fmt.Errorf("failed to register CacheHits: %w", err)
+    }
+    if err := p.RegisterMetric(m.ProcessingTime); err != nil {
+        return fmt.Errorf("failed to register ProcessingTime: %w", err)
+    }
+    return nil
+}
+
+// handlers/auth.go
+package handlers
+
+import (
+    "myapp/metrics"
+    "github.com/prometheus/client_golang/prometheus"
+    "github.com/valyala/fasthttp"
+)
+
+func HandleLogin(metrics *metrics.AppMetrics) fasthttp.RequestHandler {
+    return func(ctx *fasthttp.RequestCtx) {
+        username := string(ctx.FormValue("username"))
+        if username == "" {
+            metrics.LoginAttempts.WithLabelValues("failed", "password").Inc()
+            ctx.SetStatusCode(400)
+            ctx.SetBody([]byte(`{"error": "username required"}`))
+            return
+        }
+        
+        metrics.LoginAttempts.WithLabelValues("success", "password").Inc()
+        ctx.SetStatusCode(200)
+        ctx.SetBody([]byte(`{"token": "abc123"}`))
+    }
+}
+
+func HandleData(metrics *metrics.AppMetrics) fasthttp.RequestHandler {
+    return func(ctx *fasthttp.RequestCtx) {
+        // Simulate cache lookup
+        if data := checkCache(ctx); data != "" {
+            metrics.CacheHits.Inc()
+            ctx.SetStatusCode(200)
+            ctx.SetBody([]byte(data))
+            return
+        }
+        
+        // Cache miss
+        ctx.SetStatusCode(200)
+        ctx.SetBody([]byte(`{"data": "from database"}`))
+    }
+}
+
+func HandleProcess(metrics *metrics.AppMetrics) fasthttp.RequestHandler {
+    return func(ctx *fasthttp.RequestCtx) {
+        // Track processing time
+        timer := prometheus.NewTimer(metrics.ProcessingTime.WithLabelValues("data_transformation"))
+        defer timer.ObserveDuration()
+        
+        // Process request
+        ctx.SetStatusCode(200)
+        ctx.SetBody([]byte(`{"processed": true}`))
+    }
+}
+
+// main.go
+package main
+
+import (
+    "log"
+    "myapp/metrics"
+    "myapp/handlers"
+    
+    fasthttpprom "github.com/carousell/fasthttp-prometheus-middleware"
+    "github.com/fasthttp/router"
+    "github.com/valyala/fasthttp"
+)
+
+func main() {
+    r := router.New()
+    p := fasthttpprom.NewPrometheus("myapp")
+    
+    // Create and register all app metrics
+    appMetrics := metrics.New()
+    if err := appMetrics.Register(p); err != nil {
+        log.Fatal(err)
+    }
+    
+    p.Use(r)
+    
+    // Pass metrics to handler functions
+    r.POST("/auth/login", handlers.HandleLogin(appMetrics))
+    r.GET("/api/data", handlers.HandleData(appMetrics))
+    r.POST("/api/process", handlers.HandleProcess(appMetrics))
+    
+    log.Println("Server listening on :8080")
+    log.Fatal(fasthttp.ListenAndServe(":8080", p.Handler))
+}
+```
+
+This pattern provides several benefits:
+- **Separation of concerns**: Metrics are defined separately from business logic
+- **Reusability**: Metrics can be shared across multiple handlers
+- **Testability**: Handlers can be tested with mock metrics
+- **Type safety**: Metrics struct provides compile-time safety
+- **Thread safety**: All metric registration methods are protected by mutex
+
+### Supported Metric Types
+
+All Prometheus metric types are supported:
+- **Counter** - Monotonically increasing value (e.g., request counts, login attempts)
+- **Gauge** - Value that can go up and down (e.g., memory usage, active connections)
+- **Histogram** - Samples observations and counts them in buckets (e.g., request sizes, response times)
+- **Summary** - Similar to histogram but calculates quantiles
+
+See the [example/custom_metrics_example.go](example/custom_metrics_example.go) file for complete runnable examples.
+
+## Installation
+
+```bash
+go get github.com/carousell/fasthttp-prometheus-middleware@poc-cus-metrics-2025
+```
+
+For local development without a version tag, add this to your consuming repo's `go.mod`:
+
+```go
+replace github.com/carousell/fasthttp-prometheus-middleware => /path/to/local/md-fasthttp-prometheus-middleware
+```
+

--- a/example/custom_metrics_example.go
+++ b/example/custom_metrics_example.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	fasthttpprom "github.com/carousell/fasthttp-prometheus-middleware"
+	"github.com/fasthttp/router"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/valyala/fasthttp"
+)
+
+// Advanced example: Creating metrics in a separate package/module
+// This demonstrates how to organize custom metrics in a struct and pass them to handlers
+type CustomMetrics struct {
+	LoginAttempts  *prometheus.CounterVec
+	CacheHitRate   prometheus.Counter
+	ProcessingTime *prometheus.HistogramVec
+}
+
+// NewCustomMetrics creates and initializes a CustomMetrics instance with all metrics
+// This should be called once during application startup
+func NewCustomMetrics() *CustomMetrics {
+	return &CustomMetrics{
+		LoginAttempts: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "auth_login_attempts_total",
+				Help: "Total number of login attempts",
+			},
+			[]string{"status", "method"},
+		),
+		CacheHitRate: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: "cache_hits_total",
+				Help: "Total number of cache hits",
+			},
+		),
+		ProcessingTime: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    "business_logic_processing_seconds",
+				Help:    "Time spent in business logic processing",
+				Buckets: prometheus.DefBuckets,
+			},
+			[]string{"operation"},
+		),
+	}
+}
+
+// Register registers all custom metrics with the Prometheus middleware
+// This method is safe for concurrent use due to mutex protection in RegisterMetric
+func (cm *CustomMetrics) Register(p *fasthttpprom.Prometheus) error {
+	if err := p.RegisterMetric(cm.LoginAttempts); err != nil {
+		return fmt.Errorf("failed to register LoginAttempts: %w", err)
+	}
+	if err := p.RegisterMetric(cm.CacheHitRate); err != nil {
+		return fmt.Errorf("failed to register CacheHitRate: %w", err)
+	}
+	if err := p.RegisterMetric(cm.ProcessingTime); err != nil {
+		return fmt.Errorf("failed to register ProcessingTime: %w", err)
+	}
+	return nil
+}
+
+// advancedExample demonstrates the recommended pattern for larger applications:
+// 1. Create a metrics struct to organize related metrics
+// 2. Register all metrics during initialization
+// 3. Pass metrics to handler factory functions
+// 4. Use metrics within handlers
+//
+// To run this example:
+// - Rename this function to 'main' or call it from main.go
+// - Run: go run example/*.go
+// - Test endpoints: curl -X POST http://localhost:8080/auth/login?username=test
+// - View metrics: curl http://localhost:8080/metrics
+func advancedExample() {
+	r := router.New()
+	p := fasthttpprom.NewPrometheus("myapp")
+
+	// Create and register custom metrics module
+	customMetrics := NewCustomMetrics()
+	if err := customMetrics.Register(p); err != nil {
+		log.Fatalf("Failed to register custom metrics: %v", err)
+	}
+
+	p.Use(r)
+
+	// Pass customMetrics to handler functions
+	r.POST("/auth/login", handleLogin(customMetrics))
+	r.GET("/api/data", handleData(customMetrics))
+	r.POST("/api/process", handleProcess(customMetrics))
+
+	log.Println("Server listening on :8080")
+	log.Fatal(fasthttp.ListenAndServe(":8080", p.Handler))
+}
+
+// handleLogin is a handler factory that accepts metrics and returns a configured handler
+// This pattern allows metrics to be injected and used within the handler closure
+func handleLogin(metrics *CustomMetrics) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		// Simulate login logic
+		username := string(ctx.FormValue("username"))
+		if username == "" {
+			metrics.LoginAttempts.WithLabelValues("failed", "password").Inc()
+			ctx.SetStatusCode(400)
+			ctx.SetBody([]byte(`{"error": "username required"}`))
+			return
+		}
+
+		// Successful login
+		metrics.LoginAttempts.WithLabelValues("success", "password").Inc()
+		ctx.SetStatusCode(200)
+		ctx.SetBody([]byte(`{"token": "abc123"}`))
+	}
+}
+
+// handleData demonstrates using a counter metric to track cache hits
+func handleData(metrics *CustomMetrics) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		dataID := string(ctx.QueryArgs().Peek("id"))
+
+		// Simulate cache lookup
+		cachedData := checkCache(dataID)
+		if cachedData != "" {
+			metrics.CacheHitRate.Inc()
+			ctx.SetStatusCode(200)
+			ctx.SetBody([]byte(cachedData))
+			return
+		}
+
+		// Cache miss - fetch from database
+		ctx.SetStatusCode(200)
+		ctx.SetBody([]byte(`{"data": "from database"}`))
+	}
+}
+
+// handleProcess demonstrates using a histogram metric to track processing duration
+func handleProcess(metrics *CustomMetrics) fasthttp.RequestHandler {
+	return func(ctx *fasthttp.RequestCtx) {
+		// Track processing time for this operation
+		timer := prometheus.NewTimer(metrics.ProcessingTime.WithLabelValues("data_transformation"))
+		defer timer.ObserveDuration()
+
+		// Simulate some processing work
+		result := performBusinessLogic(string(ctx.PostBody()))
+
+		ctx.SetStatusCode(200)
+		ctx.SetBody([]byte(result))
+	}
+}
+
+// Helper functions for the examples
+func checkCache(id string) string {
+	// Simulate cache lookup
+	if id == "cached-123" {
+		return `{"data": "from cache", "id": "cached-123"}`
+	}
+	return ""
+}
+
+func performBusinessLogic(input string) string {
+	// Simulate business logic processing
+	return fmt.Sprintf(`{"processed": true, "input_length": %d}`, len(input))
+}
+
+// customMetricsExample demonstrates basic usage with inline metrics creation
+// This is suitable for simple applications with few custom metrics
+//
+// To run this example:
+// - Rename this function to 'main' or call it from main.go
+// - Run: go run example/*.go
+// - Test endpoints: curl http://localhost:8080/api/users
+// - View metrics: curl http://localhost:8080/metrics
+func customMetricsExample() {
+	r := router.New()
+	p := fasthttpprom.NewPrometheus("myapp")
+
+	// Create custom counter metric
+	requestCounter := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "myapp_custom_requests_total",
+			Help: "Total number of custom requests",
+		},
+		[]string{"endpoint", "method"},
+	)
+
+	// Register the custom counter with the Prometheus instance
+	if err := p.RegisterMetric(requestCounter); err != nil {
+		log.Fatalf("Failed to register custom metric: %v", err)
+	}
+
+	// Create another custom metric - a gauge
+	activeConnections := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "myapp_active_connections",
+			Help: "Number of active connections",
+		},
+	)
+
+	// Use MustRegisterMetric if you want to panic on error
+	p.MustRegisterMetric(activeConnections)
+
+	// Create a histogram for response sizes
+	responseSizeHistogram := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "myapp_response_size_bytes",
+			Help:    "Response size in bytes",
+			Buckets: prometheus.ExponentialBuckets(100, 10, 8),
+		},
+		[]string{"endpoint"},
+	)
+
+	p.MustRegisterMetric(responseSizeHistogram)
+
+	p.Use(r)
+
+	// Use the custom metrics in your handlers
+	r.GET("/api/users", func(ctx *fasthttp.RequestCtx) {
+		// Increment the custom counter
+		requestCounter.WithLabelValues("/api/users", "GET").Inc()
+
+		// Simulate some work
+		activeConnections.Inc()
+		defer activeConnections.Dec()
+
+		response := []byte(`{"users": ["alice", "bob"]}`)
+
+		// Record response size
+		responseSizeHistogram.WithLabelValues("/api/users").Observe(float64(len(response)))
+
+		ctx.SetStatusCode(200)
+		ctx.SetBody(response)
+	})
+
+	r.POST("/api/orders", func(ctx *fasthttp.RequestCtx) {
+		// Track POST requests separately
+		requestCounter.WithLabelValues("/api/orders", "POST").Inc()
+
+		activeConnections.Inc()
+		defer activeConnections.Dec()
+
+		response := []byte(`{"order_id": "12345"}`)
+		responseSizeHistogram.WithLabelValues("/api/orders").Observe(float64(len(response)))
+
+		ctx.SetStatusCode(201)
+		ctx.SetBody(response)
+	})
+
+	r.GET("/health", func(ctx *fasthttp.RequestCtx) {
+		ctx.SetStatusCode(200)
+		ctx.SetBody([]byte(`{"status": "pass"}`))
+	})
+
+	log.Println("Server with custom metrics listening on :8080")
+	log.Println("Metrics available at http://localhost:8080/metrics")
+	log.Fatal(fasthttp.ListenAndServe(":8080", p.Handler))
+}

--- a/prometheus.go
+++ b/prometheus.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/fasthttp/router"
@@ -26,6 +27,7 @@ type Prometheus struct {
 	MetricsPath   string
 	Handler       fasthttp.RequestHandler
 	customMetrics []prometheus.Collector
+	mu            sync.Mutex
 }
 
 // NewPrometheus generates a new set of metrics with a certain subsystem name
@@ -88,7 +90,11 @@ func (p *Prometheus) registerMetrics(subsystem string) {
 
 // RegisterMetric allows external packages to register custom Prometheus metrics
 // This can be used to add counters, gauges, histograms, or summaries
+// This method is safe for concurrent use.
 func (p *Prometheus) RegisterMetric(collector prometheus.Collector) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if err := prometheus.Register(collector); err != nil {
 		return err
 	}
@@ -103,10 +109,17 @@ func (p *Prometheus) MustRegisterMetric(collector prometheus.Collector) {
 	}
 }
 
-// GetMetric retrieves a registered custom metric by searching through customMetrics
+// GetCustomMetrics retrieves all registered custom metrics.
 // Note: For better type safety, consumers should maintain their own references to metrics
+// This method is safe for concurrent use.
 func (p *Prometheus) GetCustomMetrics() []prometheus.Collector {
-	return p.customMetrics
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Return a copy to prevent external modification
+	metrics := make([]prometheus.Collector, len(p.customMetrics))
+	copy(metrics, p.customMetrics)
+	return metrics
 }
 
 // Custom adds the middleware to a fasthttp

--- a/prometheus.go
+++ b/prometheus.go
@@ -27,7 +27,7 @@ type Prometheus struct {
 	MetricsPath   string
 	Handler       fasthttp.RequestHandler
 	customMetrics []prometheus.Collector
-	mu            sync.Mutex
+	mu            sync.RWMutex
 }
 
 // NewPrometheus generates a new set of metrics with a certain subsystem name
@@ -111,10 +111,10 @@ func (p *Prometheus) MustRegisterMetric(collector prometheus.Collector) {
 
 // GetCustomMetrics retrieves all registered custom metrics.
 // Note: For better type safety, consumers should maintain their own references to metrics
-// This method is safe for concurrent use.
+// This method is safe for concurrent use and allows concurrent reads.
 func (p *Prometheus) GetCustomMetrics() []prometheus.Collector {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 
 	// Return a copy to prevent external modification
 	metrics := make([]prometheus.Collector, len(p.customMetrics))

--- a/prometheus.go
+++ b/prometheus.go
@@ -25,6 +25,7 @@ type Prometheus struct {
 	listenAddress string
 	MetricsPath   string
 	Handler       fasthttp.RequestHandler
+	customMetrics []prometheus.Collector
 }
 
 // NewPrometheus generates a new set of metrics with a certain subsystem name
@@ -83,6 +84,29 @@ func (p *Prometheus) registerMetrics(subsystem string) {
 	)
 
 	prometheus.Register(p.reqDur)
+}
+
+// RegisterMetric allows external packages to register custom Prometheus metrics
+// This can be used to add counters, gauges, histograms, or summaries
+func (p *Prometheus) RegisterMetric(collector prometheus.Collector) error {
+	if err := prometheus.Register(collector); err != nil {
+		return err
+	}
+	p.customMetrics = append(p.customMetrics, collector)
+	return nil
+}
+
+// MustRegisterMetric is like RegisterMetric but panics on error
+func (p *Prometheus) MustRegisterMetric(collector prometheus.Collector) {
+	if err := p.RegisterMetric(collector); err != nil {
+		panic(err)
+	}
+}
+
+// GetMetric retrieves a registered custom metric by searching through customMetrics
+// Note: For better type safety, consumers should maintain their own references to metrics
+func (p *Prometheus) GetCustomMetrics() []prometheus.Collector {
+	return p.customMetrics
 }
 
 // Custom adds the middleware to a fasthttp


### PR DESCRIPTION
# POC Custom Prometheus Metrics

Last good commit -  https://github.com/carousell/md-fasthttp-prometheus-middleware/pull/16/commits/51296d828414fe2b2acfa3060ad0c5a7c5fee590



〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 
Dove POC - https://github.com/carousell/md-dove/pull/643
〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 〰️ 

This pull request extends the `Prometheus` struct to support registering and managing custom Prometheus metrics, making it easier for external packages to add their own metrics. The most important changes are grouped below:

**Custom Metrics Registration and Management:**

* Added a `customMetrics` field to the `Prometheus` struct to keep track of registered custom metrics.
* Introduced the `RegisterMetric` method, allowing external packages to register custom Prometheus collectors, with error handling.
* Added the `MustRegisterMetric` method, which registers a custom metric and panics on error for convenience.
* Implemented the `GetCustomMetrics` method to retrieve all registered custom metrics from the `Prometheus` instance.