### PR TITLE
Add verify-metrics and tune-buckets Claude skills

### DIFF
--- a/.claude/skills/tune-buckets/SKILL.md
+++ b/.claude/skills/tune-buckets/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: tune-buckets
+description: Change the Prometheus histogram bucket boundaries for request_duration_seconds safely. Use when asked to add, remove, or retune latency buckets in prometheus.go. Guides the edit, explains the downstream blast radius (dashboards/alerts/SLOs), and verifies the result end-to-end.
+---
+
+# tune-buckets
+
+The histogram buckets for `request_duration_seconds` are defined in one place — the `Buckets` slice inside `registerMetrics` in `prometheus.go`:
+
+```go
+Buckets: []float64{0.1, 0.2, 0.3, 0.5, 0.75, 1, 1.5, 2, 3, 5},
+```
+
+These boundaries have been retuned across several PRs (see git history: "Update prom buckets", "remove 10, 15, 20 from bucket", "remove 7 from bucket"). Treat every change as significant — not cosmetic.
+
+## Why this is delicate
+
+Buckets are **cumulative** (`le` = "less than or equal to") and Prometheus auto-appends `+Inf`. Consumers of this library build latency dashboards, `histogram_quantile()` queries, and alert thresholds against these exact boundaries. Changing them:
+
+- **Breaks historical continuity** — a removed bucket leaves gaps in old time series; quantile estimates shift.
+- **Can silently degrade alerts** — an SLO alert keyed on `le="7"` goes dead if you remove the `7` bucket.
+- **Affects every consumer** on upgrade, since this is a published module.
+
+So the bar for a change is: it must be intentional, the values must stay **strictly ascending**, and the result must be verified.
+
+## Steps
+
+1. **Confirm the requested boundaries.** Get the exact target slice from the user. If they only say "add X" / "remove Y", restate the full resulting slice back to them before editing.
+
+2. **Edit only the `Buckets` slice** in `registerMetrics` (`prometheus.go`). Keep values **strictly ascending**; do not add `+Inf` (Prometheus adds it). Do not touch the metric name, `Help`, or label set unless asked.
+
+3. **Verify end-to-end** with the `verify-metrics` skill. Confirm the scraped `le=` boundaries in `/metrics` exactly match the new slice (plus `+Inf`).
+
+4. **Flag the blast radius in your summary.** Explicitly list which boundaries were added/removed so the reviewer knows what downstream dashboards/alerts to check. If a boundary was *removed*, call it out as a potentially breaking change for consumers.
+
+## Release note
+
+A bucket change is meaningful to consumers. When it ships, it warrants a new version tag (see the release workflow) and a one-line changelog entry describing the added/removed boundaries.

--- a/.claude/skills/verify-metrics/SKILL.md
+++ b/.claude/skills/verify-metrics/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: verify-metrics
+description: Boot the example fasthttp server, fire representative requests, scrape /metrics, and report the emitted request_duration_seconds series (labels + bucket boundaries). Use to prove a change to prometheus.go — bucket edits, dependency upgrades, or labeling logic — produces the metric output you expect. This repo has no tests, so this is the primary verification harness.
+---
+
+# verify-metrics
+
+The library in `prometheus.go` has no unit tests. The only way to confirm a change is correct is to run it and inspect real metric output. This skill does that end-to-end.
+
+## When to use
+
+- After editing the `Buckets` slice in `registerMetrics` (see the `tune-buckets` skill).
+- After a dependency bump (`fasthttp`, `fasthttp/router`, `prometheus/client_golang`) — the labeling logic in `HandlerFunc` calls `router.List()` / `router.Lookup()`, whose behavior can drift silently.
+- After changing any labeling logic (the `code` / `path` labels, the `404_<METHOD>` special case).
+
+## Steps
+
+1. **Build first.** Bail early on compile errors:
+   ```bash
+   go build ./... && go vet ./...
+   ```
+
+2. **Start the example server in the background** (it listens on `:8080`, routes `/health` and `/values/{id}`, metrics at `/metrics`):
+   ```bash
+   go run ./example &
+   ```
+   Use a background run and capture the PID so you can stop it in step 5. Poll `http://localhost:8080/health` until it responds before firing traffic.
+
+3. **Fire representative traffic** — one request per label case that matters in this codebase:
+   ```bash
+   curl -s http://localhost:8080/health        # 200, static route  -> path="GET_/health"
+   curl -s http://localhost:8080/values/123    # 200, param route   -> path MUST be "GET_/values/{id}", not ".../123"
+   curl -s http://localhost:8080/nope          # 404               -> path="404_GET" (method comes SECOND for 404s)
+   curl -s -X POST http://localhost:8080/health # 405/404 non-GET  -> confirms method handling
+   ```
+
+4. **Scrape and inspect** the metric:
+   ```bash
+   curl -s http://localhost:8080/metrics | grep request_duration_seconds
+   ```
+   Report back:
+   - The **`path` labels** — confirm `/values/123` collapsed to `GET_/values/{id}` (cardinality control working) and the 404 is `404_GET`.
+   - The **`le` bucket boundaries** — list them and confirm they match the `Buckets` slice in `prometheus.go`.
+   - The **`code` labels** map to the statuses you sent.
+
+5. **Stop the server** (kill the background PID). Don't leave `:8080` bound.
+
+## What "pass" looks like
+
+- `/values/123` produces exactly one series with `path="GET_/values/{id}"` — never a per-id label. A per-id label is a cardinality regression and a failure.
+- The `le` values in the output equal the code's `Buckets` slice plus `+Inf`.
+- No panic in the server log (historically, invalid labels have panicked — see commit `cde5490`).
+
+Report the actual scraped output, not just a pass/fail verdict.

--- a/.claude/skills/verify-metrics/SKILL.md
+++ b/.claude/skills/verify-metrics/SKILL.md
@@ -43,7 +43,7 @@ The library in `prometheus.go` has no unit tests. The only way to confirm a chan
    - The **`le` bucket boundaries** — list them and confirm they match the `Buckets` slice in `prometheus.go`.
    - The **`code` labels** map to the statuses you sent.
 
-5. **Stop the server** (kill the background PID). Don't leave `:8080` bound.
+5. **Stop the server** (e.g. `kill "$pid"`). Don't leave `:8080` bound.
 
 ## What "pass" looks like
 

--- a/.claude/skills/verify-metrics/SKILL.md
+++ b/.claude/skills/verify-metrics/SKILL.md
@@ -22,9 +22,9 @@ The library in `prometheus.go` has no unit tests. The only way to confirm a chan
 
 2. **Start the example server in the background** (it listens on `:8080`, routes `/health` and `/values/{id}`, metrics at `/metrics`):
    ```bash
-   go run ./example &
+   go run ./example & pid=$!
    ```
-   Use a background run and capture the PID so you can stop it in step 5. Poll `http://localhost:8080/health` until it responds before firing traffic.
+   Use a background run and capture the PID in `pid` so you can stop it in step 5. Poll `http://localhost:8080/health` until it responds before firing traffic.
 
 3. **Fire representative traffic** — one request per label case that matters in this codebase:
    ```bash

--- a/README.md
+++ b/README.md
@@ -57,3 +57,22 @@ request_duration_seconds_bucket{code="200",path="GET_/health",le="5"} 25063
 request_duration_seconds_bucket{code="200",path="GET_/health",le="+Inf"} 25063
 request_duration_seconds_sum{code="200",path="GET_/health"} 0.14781658099999923
 request_duration_seconds_count{code="200",path="GET_/health"} 25063
+```
+
+## Claude Code skills
+
+This repo ships two project skills (in `.claude/skills/`) for common maintenance work. In Claude Code, invoke them by name or with a slash command.
+
+### `verify-metrics`
+Boots the example server, fires representative requests, scrapes `/metrics`, and reports the emitted `request_duration_seconds` series (labels + bucket boundaries). Since the library has no unit tests, this is the primary way to confirm a change is correct.
+
+Use it after any change to `prometheus.go` — bucket edits, dependency upgrades, or labeling logic. Ask Claude:
+
+    /verify-metrics
+
+It confirms, among other things, that `/values/123` collapses to the label `path="GET_/values/{id}"` (cardinality control) rather than exploding per-id.
+
+### `tune-buckets`
+Safely changes the histogram bucket boundaries for `request_duration_seconds` (the `Buckets` slice in `prometheus.go`). It restates the resulting slice, keeps values strictly ascending, verifies the output via `verify-metrics`, and flags the downstream blast radius (dashboards / alerts / SLOs) since these boundaries are consumed by everyone who upgrades. Ask Claude:
+
+    /tune-buckets add a 0.05 bucket and remove 5


### PR DESCRIPTION
Add two project skills under .claude/skills/ for the recurring maintenance work this repo sees:

- verify-metrics: boots the example server, fires representative requests, scrapes /metrics, and reports the emitted request_duration_seconds series. Serves as the verification harness the repo otherwise lacks (no unit tests).
- tune-buckets: safely edits the histogram Buckets slice in prometheus.go, keeps boundaries ascending, verifies via verify-metrics, and flags the downstream blast radius.

Document both skills in README.md.